### PR TITLE
Fixes bug when typing over selected text

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -22,13 +22,25 @@ const handleBeforeInput = stream$ => (chars, editorState) => {
 
   if (entity === null) {
     const style = editorState.getCurrentInlineStyle()
-    const newContent = Modifier.insertText(
-      content,
-      selection,
-      chars,
-      style,
-      null
-    )
+    let newContent;
+    
+    if (!selection.isCollapsed()) {
+      newContent = Modifier.replaceText(
+        content,
+        selection,
+        chars,
+        style,
+        null,
+      )
+    } else {
+      newContent = Modifier.insertText(
+        content,
+        selection,
+        chars,
+        style,
+        null
+      )
+    }
     stream$.next(EditorState.push(editorState, newContent, 'insert-characters'))
 
     return 'handled'


### PR DESCRIPTION
When text is selected (i.e. the selection state is not collapsed), typing any character will invoke the `insertText` method, which in turn throws an error because `replaceText` should be the operation used instead.